### PR TITLE
Change header level for included files (replacement PR)

### DIFF
--- a/IncludeFilter.hs
+++ b/IncludeFilter.hs
@@ -75,8 +75,8 @@ import           Control.Error (readMay, fromMaybe)
 import           System.Directory
 
 import           Text.Pandoc
+import           Text.Pandoc.Shared (uniqueIdent, stringify)
 import           Text.Pandoc.Error
-import           Text.Pandoc.Shared
 import           Text.Pandoc.JSON
 import           Text.Pandoc.Walk
 
@@ -89,6 +89,7 @@ stripPandoc changeInHeaderLevel (Right (Pandoc meta blocks)) = maybe id (:) (tit
              guard $ changeInHeaderLevel > 0
              Just $ Header changeInHeaderLevel (titleRef inls,["section-title"],[]) inls
          title _ = Nothing
+         -- WARNING titleRef doesn't check that titles are unique; for that try uniqueIdent.
          titleRef = stringify . fmap (lowerCase . dashFromSpace)
          dashFromSpace Space = Str "-"
          dashFromSpace x = x

--- a/IncludeFilter.hs
+++ b/IncludeFilter.hs
@@ -69,12 +69,14 @@ example, if the header is incremented by 1, the title is inserted as a level 1 h
 
 import           Control.Monad
 import           Data.List
+import qualified Data.Char as C
 import qualified Data.Map as Map
 import           Control.Error (readMay, fromMaybe)
 import           System.Directory
 
 import           Text.Pandoc
 import           Text.Pandoc.Error
+import           Text.Pandoc.Shared
 import           Text.Pandoc.JSON
 import           Text.Pandoc.Walk
 
@@ -85,8 +87,13 @@ stripPandoc changeInHeaderLevel (Right (Pandoc meta blocks)) = maybe id (:) (tit
          modBlocks = modifyHeaderLevelBlockWith changeInHeaderLevel <$> blocks
          title (Meta (Map.lookup "title" -> Just (MetaInlines inls))) = do
              guard $ changeInHeaderLevel > 0
-             Just $ Header changeInHeaderLevel ("",["section-title"],[]) inls
+             Just $ Header changeInHeaderLevel (titleRef inls,["section-title"],[]) inls
          title _ = Nothing
+         titleRef = stringify . fmap (lowerCase . dashFromSpace)
+         dashFromSpace Space = Str "-"
+         dashFromSpace x = x
+         lowerCase (Str x) = Str (fmap C.toLower x)
+         lowerCase x = x
 
 modifyHeaderLevelBlockWith :: Int -> Block -> Block
 modifyHeaderLevelBlockWith n (Header int att inls) = Header (int + n) att inls

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ pandoc command will be executed.
     #do/not/include/this.md
     ```
 
+Alternatively, use the following to increase all the header numbers by one in
+the included file.
+
+    ```include-indented
+
 If the file does not exist, it will be skipped completely. No warnings, no
 residue, nothing. Putting an `#` as the first character in the line will make the
 filter skip that file.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ pandoc command will be executed.
     relative/to/the/command/root.md
     #do/not/include/this.md
     ```
+If the file does not exist, it will be skipped completely. No warnings, no
+residue, nothing. Putting an `#` as the first character in the line will make the
+filter skip that file.
+
+For now the nested includes only work for two levels, after that the source
+will be inserted and not parsed.
+
+*Note: the metadata from the included source files are discarded.*
 
 Alternatively, use one of the following to increase all the header levels in the
 included file. The first option is a shortcut for incrementing the level by 1.
@@ -24,14 +32,10 @@ The second demonstrates an increase of 2.
 
     ```{ .include header-change=2 }
 
-If the file does not exist, it will be skipped completely. No warnings, no
-residue, nothing. Putting an `#` as the first character in the line will make the
-filter skip that file.
 
-For now the nested includes only work for two levels, after that the source
-will be inserted and not parsed.
-
-*Note: the metadata from the included source files are discarded.*
+If the header level is increased, the title from the included file is inserted at the
+beginning of the included file as a header, at the level of the header level change. For
+example, if the header is incremented by 1, the title is inserted as a level 1 heading.
 
 ## Installation
 One could either install it using the Cabal packaging system by running:

--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ pandoc command will be executed.
     #do/not/include/this.md
     ```
 
-Alternatively, use the following to increase all the header numbers by one in
-the included file.
+Alternatively, use one of the following to increase all the header levels in the
+included file. The first option is a shortcut for incrementing the level by 1.
+The second demonstrates an increase of 2.
 
     ```include-indented
+
+    ```{ .include header-change=2 }
 
 If the file does not exist, it will be skipped completely. No warnings, no
 residue, nothing. Putting an `#` as the first character in the line will make the

--- a/README.md
+++ b/README.md
@@ -10,13 +10,11 @@ The Code Blocks like the following will include every file in a new line. The
 reference paths should be either absolute or relative to the folder where the
 pandoc command will be executed.
 
-```markdown
-﻿```include
-﻿/absolute/file/path.md
-﻿relative/to/the/command/root.md
-﻿#do/not/include/this.md
-﻿```
-```
+    ```include
+    /absolute/file/path.md
+    relative/to/the/command/root.md
+    #do/not/include/this.md
+    ```
 
 If the file does not exist, it will be skipped completely. No warnings, no
 residue, nothing. Putting an `#` as the first character in the line will make the

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ All this does in the background is pipelining the output of Pandoc and the last 
 pandoc --from markdown --to json input.md | runhaskell IncludeFilter.hs | pandoc --from json --to latex
 ```
 
+If using *pandoc-include* together with [*pandoc-citeproc*](https://github.com/jgm/pandoc-citeproc) one has to pay attention to the order of the filters: 1. *pandoc-include*, 2. *pandoc-citeproc*.
+
+```
+pandoc -o output.md --filter pandoc-include --filter pandoc-citeproc input.md
+```
+
 ## License
 Copyright ©2015 [Dániel Stein](https://twitter.com/steindani)
 

--- a/pandoc-include.cabal
+++ b/pandoc-include.cabal
@@ -1,5 +1,5 @@
 Name:                 pandoc-include
-Version:              0.0.1
+Version:              0.0.2
 Synopsis:             Include other Markdown files
 Description:          A Pandoc filter that replaces include labeled
                       Code Blocks with the contents of the referenced

--- a/pandoc-include.cabal
+++ b/pandoc-include.cabal
@@ -23,6 +23,7 @@ Source-repository     head
 
 Library
   Build-Depends:      base >= 4.6 && < 5,
+                      containers >= 0.3,
                       errors >= 2.0.0,
                       text >= 0.11,
                       pandoc >= 1.13.0.0,
@@ -36,6 +37,7 @@ Library
 
 Executable pandoc-include
   Build-Depends:      base >= 4.6,
+                      containers >= 0.3,
                       errors >= 2.0.0,
                       text >= 0.11,
                       pandoc >= 1.13.0.0,

--- a/pandoc-include.cabal
+++ b/pandoc-include.cabal
@@ -23,6 +23,7 @@ Source-repository     head
 
 Library
   Build-Depends:      base >= 4.6 && < 5,
+                      errors >= 2.0.0,
                       text >= 0.11,
                       pandoc >= 1.13.0.0,
                       pandoc-types >= 1.12.0.0,
@@ -35,6 +36,7 @@ Library
 
 Executable pandoc-include
   Build-Depends:      base >= 4.6,
+                      errors >= 2.0.0,
                       text >= 0.11,
                       pandoc >= 1.13.0.0,
                       pandoc-types >= 1.12.0.0,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+flags: {}
+resolver: lts-6.4
+packages:
+- '.'
+extra-deps: []

--- a/test/alpha.md
+++ b/test/alpha.md
@@ -1,3 +1,7 @@
+% The Title is Alpha
+% An author
+% 11 Aug 2016
+
 # Alpha!
 
 Text from alpha.

--- a/test/input.md
+++ b/test/input.md
@@ -11,4 +11,8 @@ gamma.md
 beta.md
 ```
 
+```include-indented
+alpha.md
+```
+
 text

--- a/test/input.md
+++ b/test/input.md
@@ -15,4 +15,8 @@ beta.md
 alpha.md
 ```
 
+```{ .include header-change=2 }
+alpha.md
+```
+
 text


### PR DESCRIPTION
Use `include-indented` or `{ .include header-change=1}` to increase the header level for included files.

Also adds a `stack.yaml` and increments the release number to `0.0.2`.

As to how it works, it carries an extra parameter for the change in header level, defaulting to 0, and applies it to every header block in the markdown files that get read in.

The use case is a set of files that can used alone or be included nested in a larger document.

The indenting option now includes the title of the included file as a header.

(This replaces #3 as it means I can use my develop branch)